### PR TITLE
Revert back to stretch.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM debian
+FROM debian:stretch
 
 MAINTAINER maugin.thomas@gmail.com
 
 ENV TINI_VERSION v0.18.0
 ENV RTL_SDR_VERSION v0.6.0
-ENV DUMP1090_VERSION v3.7.2
+ENV DUMP1090_VERSION v3.8.0
 ENV PIAWARE_VERSION v3.8.0
 
 RUN apt-get update && \


### PR DESCRIPTION
Debian Buster uses glibc 2.28. Using mlat in frfeed24 don't work with glibc 2.28. It crashes during startup. Debian Stretch uses 2.24 which frfeed24 works better with.