### PR TITLE
fix: fix download file depending on arch for fr24 and s6overlay

### DIFF
--- a/build/fr24feed.sh
+++ b/build/fr24feed.sh
@@ -1,14 +1,20 @@
 #!/bin/sh
-arch=$(arch)
-
+arch=$(dpkg --print-architecture)
 case $arch in
-  armv7l)
+  armhf)
     url=https://repo-feed.flightradar24.com/rpi_binaries/fr24feed_${FR24FEED_VERSION}_armhf.tgz
     dirname=fr24feed_armhf
     ;;
-  *)
+  armel)
+    url=https://repo-feed.flightradar24.com/rpi_binaries/fr24feed_${FR24FEED_VERSION}_armhf.tgz
+    dirname=fr24feed_armhf
+    ;;
+  amd64)
     url=https://repo-feed.flightradar24.com/linux_x86_64_binaries/fr24feed_${FR24FEED_VERSION}_amd64.tgz
     dirname=fr24feed_amd64
+    ;;
+  *)
+    exit 1
     ;;
 esac
 

--- a/build/fr24feed.sh
+++ b/build/fr24feed.sh
@@ -1,12 +1,8 @@
 #!/bin/sh
-arch=$(uname -m)
+arch=$(arch)
 
 case $arch in
   armv7l)
-    url=https://repo-feed.flightradar24.com/rpi_binaries/fr24feed_${FR24FEED_VERSION}_armhf.tgz
-    dirname=fr24feed_armhf
-    ;;
-  armv6l)
     url=https://repo-feed.flightradar24.com/rpi_binaries/fr24feed_${FR24FEED_VERSION}_armhf.tgz
     dirname=fr24feed_armhf
     ;;

--- a/build/s6-overlay.sh
+++ b/build/s6-overlay.sh
@@ -1,11 +1,8 @@
 #!/bin/sh
-arch=$(uname -m)
+arch=$(arch)
 
 case $arch in
   armv7l)
-    url=https://github.com/just-containers/s6-overlay/releases/download/v1.21.8.0/s6-overlay-armhf.tar.gz
-    ;;
-  armv6l)
     url=https://github.com/just-containers/s6-overlay/releases/download/v1.21.8.0/s6-overlay-armhf.tar.gz
     ;;
   *)

--- a/build/s6-overlay.sh
+++ b/build/s6-overlay.sh
@@ -1,12 +1,18 @@
 #!/bin/sh
-arch=$(arch)
+arch=$(dpkg --print-architecture)
 
 case $arch in
-  armv7l)
+  armhf)
     url=https://github.com/just-containers/s6-overlay/releases/download/v1.21.8.0/s6-overlay-armhf.tar.gz
     ;;
-  *)
+  armel)
+    url=https://github.com/just-containers/s6-overlay/releases/download/v1.21.8.0/s6-overlay-arm.tar.gz
+    ;;
+  amd64)
     url=https://github.com/just-containers/s6-overlay/releases/download/v1.21.8.0/s6-overlay-amd64.tar.gz
+    ;;
+  *)
+    exit 1
     ;;
 esac
 


### PR DESCRIPTION
Download the right files for fr24 and s6 (see #37)