### PR TITLE
Enforce ulimit to prevent possible OOM issues

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/http/run
+++ b/root/etc/s6-overlay/s6-rc.d/http/run
@@ -2,6 +2,11 @@
 
 if [ "$SERVICE_ENABLE_HTTP" != "false" ]; then
     set -eo pipefail
+    
+    # enforce ulimit like docker <=22 to prevent OOM issues
+    # see https://github.com/Thom-x/docker-fr24feed-piaware-dump1090/issues/107
+    ulimit -n 1048576
+    
     /thttpd -D -h 0.0.0.0 -p 8080 -d /usr/lib/fr24/public_html -l - -M 60 2>&1 | mawk -W interactive '{printf "%c[32m[http]%c[0m %s\n", 27, 27, $0}'
     # stdbuf ...  --  (remove blank lines from output)
     # awk -W interactive ...  (prefix log messages with color and "[http]")


### PR DESCRIPTION
Possible fix for #107 instead of #114

See https://github.com/Thom-x/docker-fr24feed-piaware-dump1090/issues/107#issuecomment-1516272951 for more information