### PR TITLE
add procps for fr24feed wizard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -355,6 +355,7 @@ RUN dpkg --add-architecture armhf && \
     rm -rf /tmp/rtl-sdr && \
     # Install dependencies
     apt-get install -y \
+    procps \
     libssl-dev \
     tcl-dev \
     chrpath \


### PR DESCRIPTION
when using the fr24feed wizard some errors – `/usr/bin/pgrep: No such file or directory` – are shown due to the missing `procps` package in the final `serve` container