### PR TITLE
Add PLANEFINDER_INPUT_HOST and PLANEFINDER_INPUT_PORT configuration

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/conf-planefinder/script
+++ b/root/etc/s6-overlay/s6-rc.d/conf-planefinder/script
@@ -3,17 +3,6 @@
 if [ "$SERVICE_ENABLE_PLANEFINDER" != "false" ]; then
     set -eo pipefail
 
-    default_value() {
-        key=${1//\-/_DASH_}
-        key=PLANEFINDER_${key^^}
-        eval "value=\${$key:-\$2}"
-        printf -v $key -- "$value"
-        export $key
-    }
-
-    default_value "input_host" "127.0.0.1"
-    default_value "input_port" "30005"
-
     if [ -z "$PLANEFINDER_SHARECODE" ]; then
         for i in {1..5}; do
             echo "FATAL: PLANEFINDER_SHARECODE not set!" | mawk -W interactive '{printf "%c[36m[planefinder]%c[0m %s\n", 27, 27, $0}'

--- a/root/etc/s6-overlay/s6-rc.d/planefinder/run
+++ b/root/etc/s6-overlay/s6-rc.d/planefinder/run
@@ -3,6 +3,17 @@
 if [ "$SERVICE_ENABLE_PLANEFINDER" != "false" ]; then
     set -eo pipefail
 
+    default_value() {
+        key=${1//\-/_DASH_}
+        key=PLANEFINDER_${key^^}
+        eval "value=\${$key:-\$2}"
+        printf -v $key -- "$value"
+        export $key
+    }
+
+    default_value "input_host" "127.0.0.1"
+    default_value "input_port" "30005"
+
     /planefinder/pfclient \
         --connection_type=1 \
         --address="${PLANEFINDER_INPUT_HOST}" \


### PR DESCRIPTION
- Added PLANEFINDER_INPUT_HOST and PLANEFINDER_INPUT_PORT env variable
   - Maintains backward compatibility with default values (127.0.0.1 and 30005)
- Update README.md with new configuration options