### PR TITLE
chore: update component versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,7 +123,7 @@ RUN set -x && \
     rm -rf ${SRCTMP} ${SRCTMP}.tar.gz && \
     # mlat-client
     URL=https://github.com/wiedehopf/mlat-client &&\
-    COMMIT_MLAT_CLIENT=6e942bca83aa4efed1bc10cfa857f67b1eba13b1 && \
+    COMMIT_MLAT_CLIENT=28ae4f7409c9dfddd2bb8984baadce5d31fdc8e3 && \
     mkdir -p $SRCTMP && wget -O ${SRCTMP}.tar.gz ${URL}/archive/${COMMIT_MLAT_CLIENT}.tar.gz && tar xf ${SRCTMP}.tar.gz -C ${SRCTMP} --strip-components=1 && \
     pushd ${SRCTMP} && \
     VENV="/usr/local/share/adsbexchange/venv" && \


### PR DESCRIPTION
## Automated Version Update

This PR updates the following component versions:

### Git Repository Tags/Releases
- **DUMP1090_VERSION**: `v10.2`
- **PIAWARE_VERSION**: `v10.2`
- **RADARBOX_MLAT_VERSION**: `v0.2.13`
- **RTL_SDR_VERSION**: `v2.0.2`

### Git Repository Commits (latest from master)
- **readsb commit**: `f535e517996ad04ce8126a58757a9b91a82fe542`
- **mlat-client commit**: `28ae4f7409c9dfddd2bb8984baadce5d31fdc8e3`
- **adsbexchange-stats commit**: `cbe5febf7e70e518d5a3550d3a2c8375b8a43c24`

### FR24FEED Versions (from JSON API)
- **FR24FEED_AMD64_VERSION**: `1.0.54-0`
- **FR24FEED_ARMHF_VERSION**: `1.0.54-0`

### PlaneFinder Versions (scraped from website)
- **PLANEFINDER_AMD64_VERSION**: ``
- **PLANEFINDER_ARM64_VERSION**: ``
- **PLANEFINDER_ARMHF_VERSION**: ``

This update was automatically generated by the version update workflow.